### PR TITLE
Fix whitespace in plugin skeleton templates (code style)

### DIFF
--- a/Skeletor.php
+++ b/Skeletor.php
@@ -256,8 +256,8 @@ class Skeletor
         }
 
         return [
-            '@@REGISTER@@' => $register,
-            '@@HANDLERS@@' => $handler,
+            '@@REGISTER@@' => rtrim($register, "\n"),
+            '@@HANDLERS@@' => rtrim($handler, "\n"),
         ];
     }
 

--- a/skel/_test/GeneralTest.php
+++ b/skel/_test/GeneralTest.php
@@ -12,7 +12,6 @@ use DokuWikiTest;
  */
 class GeneralTest extends DokuWikiTest
 {
-
     /**
      * Simple test to make sure the @@PLUGIN_TYPE@@.info.txt is in correct format
      */
@@ -81,6 +80,5 @@ class GeneralTest extends DokuWikiTest
                 );
             }
         }
-
     }
 }

--- a/skel/action.php
+++ b/skel/action.php
@@ -17,6 +17,5 @@ class @@PLUGIN_COMPONENT_NAME@@ extends ActionPlugin
     {
 @@REGISTER@@
     }
-
 @@HANDLERS@@
 }

--- a/skel/cli.php
+++ b/skel/cli.php
@@ -10,7 +10,6 @@ use splitbrain\phpcli\Options;
  */
 class @@PLUGIN_COMPONENT_NAME@@ extends \dokuwiki\Extension\CLIPlugin
 {
-
     /** @inheritDoc */
     protected function setup(Options $options)
     {
@@ -33,6 +32,4 @@ class @@PLUGIN_COMPONENT_NAME@@ extends \dokuwiki\Extension\CLIPlugin
         // $command = $options->getCmd()
         // $arguments = $options->getArgs()
     }
-
 }
-

--- a/skel/conf/default.php
+++ b/skel/conf/default.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Default settings for the @@PLUGIN_NAME@@ plugin
  *
@@ -6,4 +7,3 @@
  */
 
 //$conf['fixme']    = 'FIXME';
-

--- a/skel/conf/metadata.php
+++ b/skel/conf/metadata.php
@@ -1,10 +1,9 @@
 <?php
+
 /**
  * Options for the @@PLUGIN_NAME@@ plugin
  *
  * @author @@AUTHOR_NAME@@ <@@AUTHOR_MAIL@@>
  */
 
-
 //$meta['fixme'] = array('string');
-

--- a/skel/lang/lang.php
+++ b/skel/lang/lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * English language file for @@PLUGIN_NAME@@ plugin
  *
@@ -10,4 +11,3 @@
 
 // custom language strings for the plugin
 // $lang['fixme'] = 'FIXME';
-

--- a/skel/lang/settings.php
+++ b/skel/lang/settings.php
@@ -1,10 +1,10 @@
 <?php
+
 /**
- * english language file for @@PLUGIN_NAME@@ plugin
+ * English language file for @@PLUGIN_NAME@@ plugin
  *
  * @author @@AUTHOR_NAME@@ <@@AUTHOR_MAIL@@>
  */
 
 // keys need to match the config setting name
 // $lang['fixme'] = 'FIXME';
-


### PR DESCRIPTION
No real code changes, only whitespace fixes to eliminate CodeSniffer errors on autogenerated code.